### PR TITLE
UUID index for capped feeds

### DIFF
--- a/lib/realself/feed/capped.rb
+++ b/lib/realself/feed/capped.rb
@@ -27,6 +27,10 @@ module RealSelf
             :key        => {:'feed.activity.redacted' => Mongo::Index::DESCENDING},
             :background => background,
             :sparse     => true
+          },
+          {
+            :key        => {:'feed.activity.uuid' => Mongo::Index::DESCENDING},
+            :background => background
           }
         ])
       end

--- a/lib/stream/version.rb
+++ b/lib/stream/version.rb
@@ -2,7 +2,7 @@ module RealSelf
   module Stream
     MAJOR         = 2
     MINOR         = 3
-    BUILD_NUMBER  = 6
+    BUILD_NUMBER  = 7
 
     VERSION = "#{MAJOR}.#{MINOR}.#{BUILD_NUMBER}"
   end

--- a/lib/tasks/daemon_tasks.rake
+++ b/lib/tasks/daemon_tasks.rake
@@ -15,53 +15,55 @@ module RealSelf
         ch = connection.channel
         error_queue = ch.queue(error_queue_name, :durable => true)
 
-        message_count = limit || error_queue.message_count
+        message_count = [limit.to_i, error_queue.message_count].min
         puts("#{error_queue_name} size: #{message_count}")
         processed = 0;
 
         consumer = Bunny::Consumer.new(ch, error_queue, ch.generate_consumer_tag, false, true)
 
-        consumer.on_delivery do |delivery_info, properties, payload|
-          begin
-            # attempt to parse the original message out of the error message wrapper
-            message   = JSON.parse(payload, :symbolize_names => true)
-            payload   = Base64.decode64(message[:payload])
-            puts "replaying activity:  #{payload}"
-            activity  = RealSelf::Stream::Factory.from_json(content_type, payload)
+        unless 0 >= message_count
+          consumer.on_delivery do |delivery_info, properties, payload|
+            begin
+              # attempt to parse the original message out of the error message wrapper
+              message   = JSON.parse(payload, :symbolize_names => true)
+              payload   = Base64.decode64(message[:payload])
+              puts "replaying activity:  #{payload}"
+              activity  = RealSelf::Stream::Factory.from_json(content_type, payload)
 
-            # publish it back to the originating queue
-            publish_queue = ch.queue(queue_name,
-              :durable => true,
-              :arguments => {
-                :'x-dead-letter-exchange' => "#{queue_name}-retry"
-                 # :'x-message-ttl' => 10000  # must match value used in Sneakers.configure in bin/steelhead-daemon
-                })
+              # publish it back to the originating queue
+              publish_queue = ch.queue(queue_name,
+                :durable => true,
+                :arguments => {
+                  :'x-dead-letter-exchange' => "#{queue_name}-retry"
+                   # :'x-message-ttl' => 10000  # must match value used in Sneakers.configure in bin/steelhead-daemon
+                  })
 
-            publish_queue.publish(activity.to_s, {:content_type => content_type})
+              publish_queue.publish(activity.to_s, {:content_type => content_type})
 
-            # ack the message
-            ch.acknowledge(delivery_info.delivery_tag, false)
+              # ack the message
+              ch.acknowledge(delivery_info.delivery_tag, false)
 
-          rescue StandardError => se
-            puts "failed to parse message:  #{payload.to_s}"
-            puts "#{se.message}\n#{se.backtrace}"
+            rescue StandardError => se
+              puts "failed to parse message:  #{payload.to_s}"
+              puts "#{se.message}\n#{se.backtrace}"
 
-            # reject the message and requeue it in the error queue
-            ch.reject(delivery_info.delivery_tag, true)
+              # reject the message and requeue it in the error queue
+              ch.reject(delivery_info.delivery_tag, true)
 
-          ensure
-            processed += 1
+            ensure
+              processed += 1
 
-            puts "processed #{processed}/#{message_count}"
+              puts "processed #{processed}/#{message_count}"
 
-            if message_count <= processed
-              consumer.cancel
-              break
+              if message_count <= processed
+                consumer.cancel
+                break
+              end
             end
           end
-        end
 
-        error_queue.subscribe_with(consumer, {:block => true})
+          error_queue.subscribe_with(consumer, {:block => true})
+        end
 
         puts "processed #{message_count} errors"
 

--- a/spec/integration/realself/feed/capped_spec.rb
+++ b/spec/integration/realself/feed/capped_spec.rb
@@ -63,13 +63,15 @@ describe RealSelf::Feed::Capped do
         case index[:name]
         when "_id_"
           index[:name]
+        when "feed.activity.uuid_-1"
+          index[:name]
         when "object.id_-1"
           expect(index[:key]).to eql({'object.id' => Mongo::Index::DESCENDING})
           index[:name]
         end
       end.compact
 
-      expect(result.size).to eql 2
+      expect(result.size).to eql 3
     end
   end
 


### PR DESCRIPTION
* cast limit to an integer when limiting error queue replay message count
* add index over activity UUID in capped feeds