### PR TITLE
DEVOPS-554

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    realself-stream (3.0.0)
+    realself-stream (3.1.0)
       bunny
       httparty
       json-schema
@@ -37,7 +37,7 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     json (1.8.3)
-    json-schema (2.6.1)
+    json-schema (2.6.2)
       addressable (~> 2.3.8)
     method_source (0.8.2)
     mime-types (2.99.1)

--- a/lib/realself/stream/activity.rb
+++ b/lib/realself/stream/activity.rb
@@ -12,7 +12,7 @@ module RealSelf
 
       def self.from_hash hash
         title       = hash[:title]
-        published   = DateTime.parse hash[:published]
+        published   = DateTime.parse hash[:published].to_s
         prototype   = hash[:prototype] || nil
         actor       = Objekt.from_hash hash[:actor]
         verb        = hash[:verb].to_s
@@ -89,7 +89,7 @@ module RealSelf
 
         hash = {
           :title      => @title,
-          :published  => @published.to_s,
+          :published  => @published,
           :actor      => @actor.to_h,
           :verb       => @verb,
           :object     => @object.to_h,

--- a/lib/realself/stream/followed_activity.rb
+++ b/lib/realself/stream/followed_activity.rb
@@ -10,7 +10,7 @@ module RealSelf
 
       def self.from_hash hash
           title       = hash[:title]
-          published   = DateTime.parse hash[:published]
+          published   = DateTime.parse hash[:published].to_s
           prototype   = hash[:prototype] || nil
           actor       = FollowedObjekt.from_hash hash[:actor]
           verb        = hash[:verb].to_s
@@ -163,7 +163,7 @@ module RealSelf
 
         hash = {
           :title      => @title,
-          :published  => @published.to_s,
+          :published  => @published,
           :actor      => @actor.to_h,
           :verb       => @verb,
           :object     => @object.to_h,

--- a/lib/stream/version.rb
+++ b/lib/stream/version.rb
@@ -1,7 +1,7 @@
 module RealSelf
   module Stream
     MAJOR         = 3
-    MINOR         = 0
+    MINOR         = 1
     BUILD_NUMBER  = 0
 
     VERSION = "#{MAJOR}.#{MINOR}.#{BUILD_NUMBER}"

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -11,7 +11,7 @@ module Helpers
   def self.example_hash
     {
       :title      => "sample activity title",
-      :published  => "1970-01-01T00:00:00+00:00",
+      :published  => DateTime.parse("1970-01-01T00:00:00+00:00"),
       :actor      => {:type => "dr", :id => "1234"},
       :verb       => "author",
       :object     => {:type => "answer", :id => "2345"},
@@ -104,7 +104,7 @@ module Helpers
 
   def self.followed_activity_hash(actor_id)
     {
-      :published => "1970-01-01T00:00:00+00:00",
+      :published => DateTime.parse("1970-01-01T00:00:00+00:00"),
       :title => "QUEUE ITEM - dr(57433) author answer(1050916) about question(1048591)",
       :actor =>
       {

--- a/spec/unit/realself/stream/activity_spec.rb
+++ b/spec/unit/realself/stream/activity_spec.rb
@@ -33,6 +33,14 @@ describe RealSelf::Stream::Activity do
       expect(activity).to be_an_instance_of RealSelf::Stream::Activity
       expect(activity.version).to eql 2
     end
+
+    it "can create an activity with a date string in the hash" do
+      hash = Helpers.example_hash
+      hash[:published] = hash[:published].to_s
+      activity = RealSelf::Stream::Activity.from_hash(hash)
+      expect(activity).to be_an_instance_of RealSelf::Stream::Activity
+      expect(activity.version).to eql 2
+    end
   end
 
 

--- a/spec/unit/realself/stream/followed_activity_spec.rb
+++ b/spec/unit/realself/stream/followed_activity_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe RealSelf::Stream::FollowedActivity do
 
 
@@ -28,6 +30,13 @@ describe RealSelf::Stream::FollowedActivity do
   describe "::from_hash" do
     it "can create a followed_activity" do
       followed_activity = RealSelf::Stream::FollowedActivity.from_hash(Helpers.followed_activity_hash(1234))
+      expect(followed_activity).to be_an_instance_of RealSelf::Stream::FollowedActivity
+    end
+
+    it "can create a followed_activity with a date string in the hash" do
+      hash = Helpers.followed_activity_hash(1234)
+      hash[:published] = hash[:published].to_s
+      followed_activity = RealSelf::Stream::FollowedActivity.from_hash(hash)
       expect(followed_activity).to be_an_instance_of RealSelf::Stream::FollowedActivity
     end
   end


### PR DESCRIPTION
* store `activity.published` attreibute in mongo as ISODate instead of string
* ensure interoperability between string and ISODate dates
* update tests
* bump version number