### PR TITLE
Capped feed query now supports complex query

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    realself-stream (3.5.2)
+    realself-stream (3.5.3)
       bunny
       connection_pool (= 2.2.0)
       httparty
@@ -63,7 +63,7 @@ GEM
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.2)
+    rspec-core (3.5.3)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)

--- a/lib/stream/version.rb
+++ b/lib/stream/version.rb
@@ -2,7 +2,7 @@ module RealSelf
   module Stream
     MAJOR         = 3
     MINOR         = 5
-    BUILD_NUMBER  = 2
+    BUILD_NUMBER  = 3
 
     VERSION = "#{MAJOR}.#{MINOR}.#{BUILD_NUMBER}"
   end

--- a/spec/integration/realself/feed/getable_shared_examples.rb
+++ b/spec/integration/realself/feed/getable_shared_examples.rb
@@ -115,6 +115,23 @@ shared_examples RealSelf::Feed::Getable do |feed|
           expect(result[:count]).to eql 1
           expect(result[:stream_items][0][:activity][:prototype]).to eql 'user.update.thing'
       end
+
+      it 'executes complex filters' do
+        result = @feed.get @owner, 10
+        expect(result[:count]).to eql 5
+        activity = Helpers.user_update_thing_activity
+        sa       = RealSelf::Stream::StreamActivity.new(
+          @owner,
+          activity,
+          [@owner])
+
+        @feed.insert @owner, sa
+
+        query   = {:$or => [{:'activity.prototype' => 'user.create.thing'}, {:'activity.uuid' => activity.uuid}]}
+        result  = @feed.get @owner, nil, nil, nil, query
+
+        expect(result[:count]).to eql 6
+      end
     end
   end
 end


### PR DESCRIPTION
handles       
```
# {:$or=>[{:"activity.prototype"=>"user.create.thing"}, {:"activity.uuid"=>"46d0e380-c126-40b0-a58a-b7d04e4fabc8"}]}
```
to
```
# {:$or=>[{:"feed.activity.prototype"=>"user.create.thing"}, {:"feed.activity.uuid"=>"46d0e380-c126-40b0-a58a-b7d04e4fabc8"}]}
```